### PR TITLE
Dwell time calculation while a video in iFrame is getting played

### DIFF
--- a/timeme.js
+++ b/timeme.js
@@ -320,7 +320,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 					TimeMe.triggerUserHasReturned();
 				});
 
-				document.addEventListener("mousemove", function () { TimeMe.resetIdleCountdown(); });
+				document.addEventListener("mousemove", function () { 
+					window.focus();
+					TimeMe.resetIdleCountdown(); 
+				});
 				document.addEventListener("keyup", function () { TimeMe.resetIdleCountdown(); });
 				document.addEventListener("touchstart", function () { TimeMe.resetIdleCountdown(); });
 				window.addEventListener("scroll", function () { TimeMe.resetIdleCountdown(); });


### PR DESCRIPTION
When a user clicks on any iFrame Timer will stop as window gets blur. Timer will start again only when it gets focus. It will get focus by clicking on the page. So in addition to that now timer will also start when user moves mouse on screen.